### PR TITLE
feat: 트랜잭션 적용 및 테스트 안정화

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier . --write",
-    "test": "jest",
+    "test": "jest --runInBand",
     "test:watch": "jest --watch",
     "coverage": "jest --coverage"
   },

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import { healthRouter } from './routes/health';
 import { usersRouter } from './routes/users';
 import { errorHandler } from './errors/errorHandler';
 import { authRouter } from './routes/auth';
+import { pgErrorTranslator } from './middlewares/pgErrorTranlator';
 
 let swaggerSpec: any | undefined;
 try {
@@ -25,6 +26,7 @@ export function createApp(): express.Express {
 
   app.use('/users', usersRouter);
 
+  app.use(pgErrorTranslator);
   app.use(errorHandler);
   return app;
 }

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -22,12 +22,16 @@ type AuthContoller = {
   signin: Handler<null, UserSignInReqDto>;
 };
 export const authController = {
-  signin: (async (req, res) => {
-    const { accessToken, refreshToken } = await authService.signin(req.body);
+  signin: (async (req, res, next) => {
+    try {
+      const { accessToken, refreshToken } = await authService.signin(req.body);
 
-    res.setHeader('Authorization', `Bearer ${accessToken}`);
-    res.cookie(refreshCookieName, refreshToken, refreshCookieOpts);
+      res.setHeader('Authorization', `Bearer ${accessToken}`);
+      res.cookie(refreshCookieName, refreshToken, refreshCookieOpts);
 
-    return res.status(200).json(ok(null));
+      return res.status(200).json(ok(null));
+    } catch (error) {
+      next(error);
+    }
   }) satisfies Handler<null, UserSignInReqDto>,
 } satisfies AuthContoller;

--- a/src/middlewares/pgErrorTranlator.ts
+++ b/src/middlewares/pgErrorTranlator.ts
@@ -1,0 +1,19 @@
+import { AppError } from '../errors/appError';
+import type { Request, Response, NextFunction } from 'express';
+
+// Postgres 에러를 AppError로 매핑
+export function pgErrorTranslator(
+  err: Error | AppError, // 최소한 Error로 지정
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const code = err instanceof Error ? (err as any).code : undefined;
+
+  if (code === '23505') {
+    // unique_violation
+    return next(AppError.conflict('이미 해당 값이 존재합니다.'));
+  }
+
+  return next(err); // 모르는 건 그대로
+}

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,8 +1,10 @@
+import bcrypt from 'bcrypt';
 import { UserRepository } from '../repository/users.repository';
 import { AppError } from '../errors/appError';
 import { signAccessToken, signRefreshToken } from '../lib/jwt';
-import type { LoginRes, UserSignInReqDto } from '../dto/authDto';
 import { sha256 } from '../lib/hash';
+import { db } from '../db';
+import type { UserSignInReqDto, LoginRes } from '../dto/authDto';
 
 export const authService = {
   async signin(input: UserSignInReqDto): Promise<LoginRes> {
@@ -11,15 +13,30 @@ export const authService = {
       throw AppError.badRequest('이메일과 비밀번호는 필수입니다.');
     }
 
-    const user = await UserRepository.login(email, password);
-
+    // 1) 사용자 조회
+    const user = await UserRepository.findByEmail(db, email);
     if (!user) {
-      throw AppError.unauthorized('일치하는 계정 정보가 없습니다.');
+      throw AppError.unauthorized('일치하는 계정 정보가 없습니다.1');
     }
+
+    // 2) 비밀번호 검증 (DB에 해시가 있다면 bcrypt.compare)
+    const ok = await bcrypt.compare(password, user.password);
+    if (!ok) {
+      throw AppError.unauthorized('일치하는 계정 정보가 없습니다.2');
+    }
+
+    // 3) 토큰 준비 (아직 응답으로 내보내지 않음)
     const claims = { userId: user.userId, role: user.role };
+    const refreshToken = signRefreshToken(claims); // 원문
+    const refreshHash = sha256(refreshToken); // DB에는 해시 저장
+
+    // 4) 트랜잭션: RT 해시 저장(단일 세션이므로 덮어쓰기)
+    await db.transaction(async (tx) => {
+      await UserRepository.updateRefreshToken(tx, user.userId, refreshHash);
+    });
+
+    // 5) 커밋 성공 이후에만 AT 생성 & RT 반환
     const accessToken = signAccessToken(claims);
-    const refreshToken = signRefreshToken(claims);
-    await UserRepository.updateRefreshToken(user.userId, sha256(refreshToken));
     return { accessToken, refreshToken };
   },
 };

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -1,6 +1,8 @@
 import { UserRepository } from '../repository/users.repository';
 import { AppError } from '../errors/appError';
 import type { UserSignupReqDto, UserCreatedRes } from '../dto/usersDto';
+import { db } from '../db';
+import bcrypt from 'bcrypt';
 
 export const UsersService = {
   async signUp(input: UserSignupReqDto): Promise<UserCreatedRes> {
@@ -8,10 +10,17 @@ export const UsersService = {
     if (!email?.trim() || !password?.trim()) {
       throw AppError.badRequest('이메일과 비밀번호는 필수입니다.');
     }
-    const dup = await UserRepository.findByEmail(email);
-    if (dup.length) throw AppError.conflict('이미 이메일이 존재합니다.');
+    const saltRounds = Number(process.env.BCRYPT_SALT_ROUNDS ?? 10);
+    const hashed = await bcrypt.hash(password, saltRounds);
 
-    const [{ userId }] = await UserRepository.create(email, password); // 해시는 다음 브랜치에서
-    return { userId };
+    return await db.transaction(async (tx) => {
+      const dup = await UserRepository.findByEmail(tx, email);
+      if (dup) {
+        throw AppError.conflict('이미 이메일이 존재합니다.');
+      }
+
+      const [{ userId }] = await UserRepository.create(tx, email, hashed);
+      return { userId };
+    });
   },
 };

--- a/test/auth.token.post.spec.ts
+++ b/test/auth.token.post.spec.ts
@@ -6,7 +6,6 @@ import { users } from '../src/db/schema';
 import { eq } from 'drizzle-orm';
 import { sha256 } from '../src/lib/hash';
 import { getCookie } from './utils/cookie';
-
 let app: Express;
 
 const testUser = {
@@ -26,13 +25,13 @@ describe('POST /auth/token', () => {
     const res = await request(app).post('/auth/token').send(payload);
     expect(res.status).toBe(200);
 
-    expect(
-      await db
-        .select()
-        .from(users)
-        .where(eq(users.userId, testUserId))
-        .then((rows) => rows[0].refreshToken),
-    ).toBe(sha256(getCookie(res, 'refreshToken') ?? ''));
+    const refreshToken = sha256(getCookie(res, 'refreshToken') ?? '');
+    const user = await db
+      .select()
+      .from(users)
+      .where(eq(users.userId, testUserId))
+      .then((rows) => rows[0]);
+    expect(user.refreshToken).toBe(refreshToken);
   });
 
   it('400 이메일이 비어있음', async () => {


### PR DESCRIPTION
- UsersService / authService에 Drizzle 트랜잭션 적용
  - 회원가입 시 중복 체크 및 유저 생성 원자적 처리
  - 로그인 시 refreshToken 해시 저장을 트랜잭션으로 보장

- 테스트 코드 개선
  - 동시성 테스트에서 Promise.all 활용해 레이스 컨디션 재현

- jest 실행 옵션 runInBand 적용
  - 테스트 파일 간 병렬 실행으로 발생한 DB 경합 문제 해결
  - 트러블슈팅.md에 추가
    - runInBand 사용 이유 및 병렬/단일 실행 시나리오 설명
    - 테스트 중 불안정하게 발생하던 409 / 201 테스트 안정화

- 기타
  - bcrypt saltRounds 환경변수 적용 (`BCRYPT_SALT_ROUNDS`)후 비밀번호 암호화 적용